### PR TITLE
Update mixins.md

### DIFF
--- a/architecture/mixins.md
+++ b/architecture/mixins.md
@@ -49,6 +49,14 @@ Good
 {: .label .label-green}
 
 ```js
+
+
+// overlay_controller.js
+import { Controller } from "stimulus";
+
+export default class extends Controller {
+}
+
 // mixins/useOverlay.js
 export const useOverlay = controller => {
   Object.assign(controller, {


### PR DESCRIPTION
Hi there,

Just checking that in the example in the "Good" section, the overlay_controller is empty - given that the `useOverlay` const has the relevant methods we are after? Otherwise things would be twice defined given the first `overlay_controller` (which also has those methods) and the const - which again has those same methods? hence this PR. feel free to close if i've made an error somewhere.

rgds

Ben